### PR TITLE
Change to static method call

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,7 @@ phpCAS::client(
 );
 
 //set the attribute callback 
-phpCAS::setCasAttributeParserCallback(
-    array(
-      new \EcasPhpCASParser\EcasPhpCASParser(),
-      'parse'
-    )
-);
+phpCAS::setCasAttributeParserCallback('\EcasPhpCASParser\EcasPhpCASParser::parse');
 
 ```
 

--- a/src/EcasPhpCASParser.php
+++ b/src/EcasPhpCASParser.php
@@ -17,7 +17,7 @@ namespace EcasPhpCASParser {
          * @return array Attributes
          * @see \phpCAS
          */
-        public function parse(\DOMElement $root)
+        public static function parse(\DOMElement $root)
         {
             phpCAS::trace('Found attribute '.$root->nodeName);
             $result = array();
@@ -55,17 +55,17 @@ namespace EcasPhpCASParser {
                         phpCas::traceBegin();
                         foreach ($child->childNodes as $groupChild) {
                             $result['groups'][]
-                                = $this->parse($groupChild);
+                                = self::parse($groupChild);
                         }
                         phpCAS::traceEnd('Parsed groups');
                     } elseif (!isset($result[$nodeName])) {
-                        $result[$nodeName] = $this->parse($child);
+                        $result[$nodeName] = self::parse($child);
                     } else {
                         if (!isset($groups[$nodeName])) {
                             $result[$nodeName] = array($result[$nodeName]);
                             $groups[$nodeName] = 1;
                         }
-                        $result[$nodeName][] = $this->parse($child);
+                        $result[$nodeName][] = self::parse($child);
                     }
                     phpCAS::traceEnd();
 


### PR DESCRIPTION
The latest phpCAS library 1.3.5 needs the parameter for the \phpCAS::setCasAttributeParserCallback() method to be a callable in form of a string, not in form of an array.

The problem is: a callable of an instance variable of a class can’t be passed as a string (because it’s apparently an object, where you call the method on). Therefore the method call '\EcasPhpCASParser\EcasPhpCASParser::parse()' must be declared static, so you can pass the callable as a string to the \phpCAS::setCasAttributeParserCallback() method.